### PR TITLE
Changes to using invoke for starting jobs

### DIFF
--- a/aws_tools/lambda_handler.py
+++ b/aws_tools/lambda_handler.py
@@ -1,0 +1,26 @@
+from __future__ import unicode_literals, print_function
+import json
+import boto3
+import logging
+from boto3 import Session
+
+
+class LambdaHandler(object):
+    def __init__(self, aws_access_key_id=None, aws_secret_access_key=None, aws_region_name='us-west-2'):
+        self.aws_access_key_id = aws_access_key_id
+        self.aws_secret_access_key = aws_secret_access_key
+        self.aws_region_name = aws_region_name
+        self.client = None
+        self.logger = logging.getLogger()
+        self.setup_resources()
+
+    def setup_resources(self):
+        self.client = boto3.client('lambda')
+
+    def invoke(self, function_name, payload):
+        return self.client.invoke(
+            FunctionName=function_name,
+            InvocationType='RequestResponse',
+            LogType='Tail',
+            Payload = json.dumps(payload)
+        )

--- a/client/client_callback.py
+++ b/client/client_callback.py
@@ -52,34 +52,18 @@ class ClientCallback(object):
         converted_zip_file = os.path.join(self.tempDir, converted_zip_url.rpartition('/')[2])
         file_utils.remove(converted_zip_file)  # make sure old file not present
         download_success = True
+        self.logger.debug('Downloading converted zip file from {0}...'.format(converted_zip_url))
         try:
-            self.logger.debug('Downloading converted zip file from {0}...'.format(converted_zip_url))
-            tries = 0
-            # Going to try to get the file every second for 200 seconds just in case there is a delay in the upload
-            # (For example, 3.6MB takes at least one minute to be seen on S3!)
-            time.sleep(5)
-            while not os.path.isfile(converted_zip_file) and tries < 200:
-                tries += 1
-                time.sleep(1)
-                try:
-                    download_file(converted_zip_url, converted_zip_file)
-                except:
-                    if self.job.errors and len(self.job.errors) > 0:
-                        download_success = False
-                        break
-
-                    if tries >= 200:
-                        if not multiple_project:  # if single project throw an exception
-                            file_utils.remove_tree(self.tempDir)  # cleanup
-                            raise
-
-                        download_success = False  # if multiple project we note fail and move on
-                        if self.job.errors is None:
-                            self.job.errors = []
-                        self.job.errors.append("Missing converted file: " + converted_zip_url)
-
+            download_file(converted_zip_url, converted_zip_file)
+        except:
+            download_success = False  # if multiple project we note fail and move on
+            if not multiple_project:
+                file_utils.remove_tree(self.tempDir)  # cleanup
+            if self.job.errors is None:
+                self.job.errors = []
+                self.job.errors.append("Missing converted file: " + converted_zip_url)
         finally:
-            self.logger.debug('download finished, success=' + str(download_success))
+            self.logger.debug('download finished, success={0}'.format(str(download_success)))
 
         if download_success:
             # Unzip the archive

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ mock==2.0.0
 sphinx==1.5.2
 sphinx-autobuild==0.6.0
 sphinx-rtd-theme==0.1.9
-moto==0.4.31
+moto==1.0.1
 PyYAML==3.12

--- a/test-setup.py
+++ b/test-setup.py
@@ -44,8 +44,9 @@ setup(
         'pyparsing==2.1.10',
         'usfm-tools==0.0.12',
         'mock',  # travis reports syntax error in mock setup.cfg if we give version
-        'moto==0.4.31',
+        'moto==1.0.1',
         'PyYAML==3.12'
     ],
     test_suite='tests'
 )
+

--- a/tests/aws_tools_tests/test_lambda_handler.py
+++ b/tests/aws_tools_tests/test_lambda_handler.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import, unicode_literals, print_function
+import io
+import json
+import zipfile
+from unittest import TestCase
+from aws_tools.lambda_handler import LambdaHandler
+from moto import mock_lambda
+
+
+@mock_lambda
+class LambdaHandlerTests(TestCase):
+    def setUp(self):
+        self.handler = LambdaHandler()
+        self.init_lambda("""
+def lambda_handler(event, context):
+    return event
+        """)
+
+    def init_lambda(self, fx):
+        zip_output = io.BytesIO()
+        zip_file = zipfile.ZipFile(zip_output, 'w', zipfile.ZIP_DEFLATED)
+        zip_file.writestr('lambda_function.zip', fx)
+        zip_file.close()
+        zip_output.seek(0)
+
+        self.handler.client.create_function(
+            FunctionName='testFunction',
+            Runtime='python2.7',
+            Role='test-iam-role',
+            Handler='lambda_function.handler',
+            Code={
+                'ZipFile': zip_output.read()
+            },
+            Description='test lambda function',
+            Timeout=3,
+            MemorySize=128,
+            Publish=True,
+        )
+
+    def test_setup_resources(self):
+        my_handler = LambdaHandler(aws_access_key_id='access_key', aws_secret_access_key='secret_key',
+                                   aws_region_name='us-west-1')
+        self.assertEqual(my_handler.aws_access_key_id, 'access_key')
+        self.assertEqual(my_handler.aws_secret_access_key, 'secret_key')
+        self.assertEqual(my_handler.aws_region_name, 'us-west-1')
+
+    def test_invoke(self):
+        result = self.handler.invoke('testFunction', {'test': 123})
+        self.assertEqual(result["StatusCode"], 202)
+        self.assertEqual(json.loads(result['Payload'].read().decode('utf-8')), {'test': 123})

--- a/tests/aws_tools_tests/test_s3_handler.py
+++ b/tests/aws_tools_tests/test_s3_handler.py
@@ -20,13 +20,14 @@ class S3HandlerTests(TestCase):
         self.handler.create_bucket()
 
     def tearDown(self):
-        shutil.rmtree(self.temp_dir+'asdfa', ignore_errors=True)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def test_setup_resources(self):
-        myHandler = S3Handler(aws_access_key_id='access_key', aws_secret_access_key='secret_key', aws_region_name='us-west-1')
-        self.assertEqual(myHandler.aws_access_key_id, 'access_key')
-        self.assertEqual(myHandler.aws_secret_access_key, 'secret_key')
-        self.assertEqual(myHandler.aws_region_name, 'us-west-1')
+        my_handler = S3Handler(aws_access_key_id='access_key', aws_secret_access_key='secret_key',
+                               aws_region_name='us-west-1')
+        self.assertEqual(my_handler.aws_access_key_id, 'access_key')
+        self.assertEqual(my_handler.aws_secret_access_key, 'secret_key')
+        self.assertEqual(my_handler.aws_region_name, 'us-west-1')
 
     def test_download_dir(self):
         key = 'from_dir/from_subdir/from_file.txt'

--- a/tests/manager_tests/test_manager.py
+++ b/tests/manager_tests/test_manager.py
@@ -338,20 +338,23 @@ class ManagerTest(unittest.TestCase):
         self.assertRaises(Exception, tx_manager.setup_job, data)
 
     # noinspection PyUnusedLocal
+    @mock.patch('aws_tools.lambda_handler.LambdaHandler.invoke')
     @mock.patch('requests.post')
-    def test_start_job1(self, mock_requests_post):
+    def test_start_job1(self, mock_request_post, mock_invoke):
         """
         Call start job in job 1 from mock data.
 
         Should be a successful invocation with warnings.
         """
-        mock_requests_post.return_value = MockResponse({
+        mock_invoke.return_value = MockResponse({
             "info": ['Converted!'],
             "warnings": ['Missing something'],
             "errors": [],
             "success": True,
             "message": "Has some warnings"
-        }, 200)
+        }, 202)
+
+        mock_request_post.return_value = None
 
         tx_manager = TxManager(**self.tx_manager_env_vars)
         tx_manager.start_job("1")
@@ -370,20 +373,24 @@ class ManagerTest(unittest.TestCase):
         self.assertTrue(len(data["warnings"]) > 0)
 
     # noinspection PyUnusedLocal
+    @mock.patch('aws_tools.lambda_handler.LambdaHandler.invoke')
     @mock.patch('requests.post')
-    def test_start_job2(self, mock_requests_post):
+    def test_start_job2(self, mock_request_post, mock_invoke):
         """
         Call start_job in job 2 from mock data.
 
         Should be a successful invocation without warnings.
         """
-        mock_requests_post.return_value = MockResponse({
+        mock_invoke.return_value = MockResponse({
             "info": ['Converted!'],
             "warnings": [],
             "errors": [],
             "success": True,
             "message": "All good"
-        }, 200)
+        }, 202)
+
+        mock_request_post.return_value = None
+
         tx_manager = TxManager(**self.tx_manager_env_vars)
         tx_manager.start_job("2")
 
@@ -400,8 +407,9 @@ class ManagerTest(unittest.TestCase):
         self.assertEqual(len(data["errors"]), 0)
 
     # noinspection PyUnusedLocal
+    @mock.patch('aws_tools.lambda_handler.LambdaHandler.invoke')
     @mock.patch('requests.post')
-    def test_start_job3(self, mock_requests_post):
+    def test_start_job3(self, mock_request_post, mock_invoke):
         """
         Call start_job on job 3 from mock data.
 
@@ -410,13 +418,15 @@ class ManagerTest(unittest.TestCase):
         :param mock_requests_post mock.MagicMock:
         :return:
         """
-        mock_requests_post.return_value = MockResponse({
+        mock_invoke.return_value = MockResponse({
             "info": ['Conversion failed!'],
             "warnings": [],
             "errors": ['Some error'],
             "success": False,
             "message": "Has errors, failed"
-        }, 200)
+        }, 202)
+
+        mock_request_post.return_value = None
 
         manager = TxManager(**self.tx_manager_env_vars)
         manager.start_job("3")
@@ -461,15 +471,17 @@ class ManagerTest(unittest.TestCase):
         self.assertTrue(len(data["errors"]) > 0)
 
     # noinspection PyUnusedLocal
+    @mock.patch('aws_tools.lambda_handler.LambdaHandler.invoke')
     @mock.patch('requests.post')
-    def test_start_job_bad_error(self, mock_requests_post):
+    def test_start_job_bad_error(self, mock_requests_post, mock_invoke):
         """
         Call start_job in job 6 from mock data.
 
         Should fail due to the response having an errorMessage
         """
         error_to_check = "something bad happened!"
-        mock_requests_post.return_value = MockResponse({"errorMessage": 'Bad Request: {0}'.format(error_to_check)}, 400)
+        mock_invoke.return_value = MockResponse({"errorMessage": 'Bad Request: {0}'.format(error_to_check)}, 400)
+        mock_requests_post.return_value = None
         tx_manager = TxManager(**self.tx_manager_env_vars)
         tx_manager.start_job("6")
         # job 0's entry in database should have been updated
@@ -486,8 +498,9 @@ class ManagerTest(unittest.TestCase):
         self.assertEqual(data["errors"][0], error_to_check)
 
     # noinspection PyUnusedLocal
+    @mock.patch('aws_tools.lambda_handler.LambdaHandler.invoke')
     @mock.patch('requests.post')
-    def test_start_job_with_errors(self, mock_requests_post):
+    def test_start_job_with_errors(self, mock_requests_post, mock_invoke):
         """
         Call start_job on job 7 from mock data.
 
@@ -496,13 +509,15 @@ class ManagerTest(unittest.TestCase):
         :param mock_requests_post mock.MagicMock:
         :return:
         """
-        mock_requests_post.return_value = MockResponse({
+        mock_invoke.return_value = MockResponse({
             "info": ['Conversion failed!'],
             "warnings": [],
             "errors": ['Some error', 'another error'],
             "success": False,
             "message": "Has errors, failed"
-        }, 200)
+        }, 202)
+
+        mock_requests_post.return_value = None
 
         manager = TxManager(**self.tx_manager_env_vars)
         manager.start_job("7")


### PR DESCRIPTION
Due to the 30 second timeout of the API Gateway we figured out a few weeks ago, we really need to get away from calling a URL for the converter and instead go back to calling lambda invoke like we used to do. This re-introduces the lambda handler, uses it to invoke the converter, and adds tests.